### PR TITLE
Add badges to see when an item has not been saved

### DIFF
--- a/app/catalogs/index/template.hbs
+++ b/app/catalogs/index/template.hbs
@@ -3,6 +3,9 @@
 
   {{#md-collection content=model as |catalog|}}
     {{#link-to 'catalogs.catalog' catalog tagName="li" classNames="collection-item avatar clickable"}}
+      {{#if catalog.isNew}}
+        {{md-badge class='red white-text' text="draft"}}
+      {{/if}}
       <i class="circle blue mdi-action-store"></i>
       <span class="title">{{catalog.title}}</span>
       <p>{{catalog.description}}</p>

--- a/app/components/catalogs/show-datasets/template.hbs
+++ b/app/components/catalogs/show-datasets/template.hbs
@@ -1,5 +1,8 @@
 {{#md-collection content=datasets as |dataset|}}
   {{#link-to 'datasets.dataset' dataset tagName="li" classNames="collection-item avatar clickable"}}
+    {{#if dataset.isNew}}
+      {{md-badge class='red white-text' text="draft"}}
+    {{/if}}
     <i class="circle blue mdi-action-assignment"></i>
     <span class="title">{{dataset.title}}</span>
     <p>{{dataset.description}}</p>

--- a/app/components/datasets/show-distributions/template.hbs
+++ b/app/components/datasets/show-distributions/template.hbs
@@ -1,5 +1,8 @@
 {{#md-collection content=distributions as |distribution|}}
   {{#link-to 'distributions.distribution' distribution tagName="li" classNames="collection-item avatar clickable"}}
+    {{#if distribution.isNew}}
+      {{md-badge class='red white-text' text="draft"}}
+    {{/if}}
     <i class="circle blue mdi-action-subject"></i>
     <span class="title">{{distribution.title}}</span>
     <p>{{distribution.description}}</p>


### PR DESCRIPTION
When the user leaves the creation form of a catalog, a dataset or a
distribution, the item appears in the list despite it hasn't been saved.
We can now distinguish which items are saved and which aren't.

Fixes #2
